### PR TITLE
Add files via upload

### DIFF
--- a/GameData/AxialAerospace/Dreamer/Parts/drm-cabin-bay.cfg
+++ b/GameData/AxialAerospace/Dreamer/Parts/drm-cabin-bay.cfg
@@ -45,7 +45,7 @@ PART
 
 	TechRequired = aerodynamicSystems
 	entryCost = 76000
-	cost = 220000
+	cost = 22000  // JVS removed extra 0
 	category = Pods
 	subcategory = 0
 	
@@ -57,7 +57,7 @@ PART
 	mass = 2.0	//.7
 	fuelCrossFeed = True
 
-	CoMOffset = 0, -1.2, 0.7
+	CoMOffset = 0, -1.0, 0.7  //0, -1.2, 0.7  // JVS moved CoM slightly forward from where it was before, based on new total lift afte rwings attached
 
 	dragModelType = default
 	maximum_drag = 0.1
@@ -68,8 +68,9 @@ PART
 	breakingForce = 300
 	breakingTorque = 300
 
-	maxTemp = 1500
-	maxSkinTemp = 2400
+	maxTemp = 2400 // JVS former 1500 is much too low for KSRSS
+	// maxSkinTemp = 2400  // JVS Shouldn't property be "skinMaxTemp"? Regardless, removed to use one temp for skin and internal.
+
 
 	MODULE
 	{
@@ -158,9 +159,9 @@ PART
 	MODULE
 	{
 		name = ModuleReactionWheel
-		PitchTorque = 25
-		YawTorque = 25
-		RollTorque = 25
+		PitchTorque = 3500  // JVS was 25, temporarily boosting to undo Skyhawk Science System nerf
+		YawTorque = 3500  // JVS was 25, temporarily boosting to undo Skyhawk Science System nerf
+		RollTorque = 3500  // JVS was 25, temporarily boosting to undo Skyhawk Science System nerf
 		torqueResponseSpeed = 50
 		RESOURCE
 		{
@@ -271,13 +272,29 @@ PART
 		storageRange = 4.0
 	}
 
+	// JVS Reenters well with full or empty tanks. Full tank is less likely to get too nose high and flip, empty tank lands at slower speeds. Pilot choice.
 	MODULE
 	{
-		name = ModuleControlSurface
-		dragCoeff = 0.20
-		deflectionLiftCoeff = 4.3	//.1
-		ctrlSurfaceRange = 35	//20 
-		ctrlSurfaceArea = 4.9		//1.5
+		name = ModuleFuelJettison
+	}
+
+// JVS replace excessively large control surface with a reduced lift module
+//	MODULE
+//	{
+//		name = ModuleControlSurface
+//		dragCoeff = 0.20
+//		deflectionLiftCoeff = 4.3	//.1
+//		ctrlSurfaceRange = 35	//20 
+//		ctrlSurfaceArea = 4.9		//1.5
+//	}
+	MODULE
+	{
+		name = ModuleLiftingSurface  // JVS replaces the original ModuleControlSurface. Not sure if below setting are ideal for the part, but combined with the 2 wings works well.
+		useInternalDragModel = True
+		deflectionLiftCoeff = 1.0
+		dragAtMaxAoA = 0.6	//0.55
+		dragAtMinAoA = 0.00	//0.2
+
 	}
 
 	MODULE

--- a/GameData/AxialAerospace/Dreamer/Parts/drm-cabin-nobay.cfg
+++ b/GameData/AxialAerospace/Dreamer/Parts/drm-cabin-nobay.cfg
@@ -25,6 +25,12 @@ PART
 	}
 
 	attachRules = 1,0,1,1,0
+
+	// JVS nose cone attachment point is too far forward and has to be manually offset each time. Other cabin with bay is better, but simply copying that node's settings here didn't place node in correct position. The bay vs non-bay models must have slightly different exterior dimensions.
+	// leaving it to zero0kerbal to deal with nodes
+	//original: node_stack_top = -0.0001, 2.90824, 0.78889, 0.0, 1.0, 0.0, 2, 1
+	//unsuccessful copy from other cabin: node_stack_top = 0.0, 2.6012, 0.55258, 0.0, 1.0, 0.0, 3, 1
+
 	node_stack_top = -0.0001, 2.90824, 0.78889, 0.0, 1.0, 0.0, 2, 1
 	node_stack_bottom = -0.0001, -6.21125, 0.46186, 0.0, -1.0, 0.0, 2, 1
 
@@ -56,7 +62,7 @@ PART
 	mass = 1.95// 2.0 //.7
 	fuelCrossFeed = True
 
-	CoMOffset =  0, 0.5, 0 //0, -3.5, 0
+	CoMOffset = 0, -1.0, 0.7  // 0, 0.5, 0 //0, -3.5, 0  // JVS this 7 crew cabin was way off compared to 4 crew cargo cabin. Tested with other cabin then copied here; might not be perfect considering different masses but should be close enough for aero controls.
 
 	dragModelType = default
 	maximum_drag = 0.1
@@ -67,8 +73,8 @@ PART
 	breakingForce = 300
 	breakingTorque = 300
 
-	maxTemp = 1500
-	maxSkinTemp = 2400
+	maxTemp = 2400 // JVS former 1500 is much too low for KSRSS
+	// maxSkinTemp = 2400  // JVS Shouldn't property be "skinMaxTemp"? Regardless, removed to use one temp for skin and internal.
 
 	MODULE
 	{
@@ -157,9 +163,9 @@ PART
 	MODULE
 	{
 		name = ModuleReactionWheel
-		PitchTorque = 35
-		YawTorque = 35
-		RollTorque = 35
+		PitchTorque = 3500  // JVS was 35, temporarily boosting to offset Skyhawk Science System nerf
+		YawTorque = 3500  // JVS was 35, temporarily boosting to offset Skyhawk Science System nerf
+		RollTorque = 3500  // JVS was 35, temporarily boosting to offset Skyhawk Science System nerf
 		torqueResponseSpeed = 40
 		RESOURCE
 		{
@@ -270,13 +276,29 @@ PART
 		storageRange = 4.0
 	}
 
+	// JVS Reenters well with full or empty tanks. Full tank is less likely to get too nose high and flip, empty tank lands at slower speeds. Pilot choice.
 	MODULE
 	{
-		name = ModuleControlSurface
-		dragCoeff = 0.20
-		deflectionLiftCoeff = 4.3	//.1
-		ctrlSurfaceRange = 35	//20 
-		ctrlSurfaceArea = 4.9		//1.5
+		name = ModuleFuelJettison
+	}
+
+// JVS replace excessively large control surface with a reduced lift module
+//	MODULE
+//	{
+//		name = ModuleControlSurface
+//		dragCoeff = 0.20
+//		deflectionLiftCoeff = 4.3	//.1
+//		ctrlSurfaceRange = 35	//20 
+//		ctrlSurfaceArea = 4.9		//1.5
+//	}
+	MODULE
+	{
+		name = ModuleLiftingSurface  // JVS replaces the original ModuleControlSurface. Not sure if below settings are ideal for the part, but combined with the 2 wings works well.
+		useInternalDragModel = True
+		deflectionLiftCoeff = 1.0
+		dragAtMaxAoA = 0.6	//0.55
+		dragAtMinAoA = 0.00	//0.2
+
 	}
 
 	MODULE

--- a/GameData/AxialAerospace/Dreamer/Parts/drm-engine-mono.cfg
+++ b/GameData/AxialAerospace/Dreamer/Parts/drm-engine-mono.cfg
@@ -1,0 +1,129 @@
+// drm-engine-mono.cfg 1.3.99.0
+// Dreamer (DREAM)
+// created: 11 Jane 2023
+// updated: 11 Jane 2023
+
+// This File: GPL-2.0 by artwhaley, zer0Kerbal, DeadJohn
+
+PART
+{
+	name = drm-engine-mono
+	module = Part
+	author = Art, zer0kerbal, DeadJohn
+
+	MODEL
+	{
+		model = AxialAerospace/Dreamer/Assets/drmengine
+	}
+	scale = 1.0
+	rescaleFactor = 2.0
+	bulkheadProfiles = size1, srf
+
+	attachRules = 1,0,1,0,1
+	stackSymmetry = 1
+	node_stack_top = 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 1, 1
+	node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0, 1
+
+	fx_exhaustFlame_blue_small = 0.0, -0.3, 0.0, 0.0, 1.0, 0.0, running
+	fx_exhaustLight_blue = 0.0, -0.3, 0.0, 0.0, 0.0, 1.0, running
+	fx_smokeTrail_light = 0.0, -0.6, 0.0, 0.0, 1.0, 0.0, running
+	fx_exhaustSparks_flameout = 0.0, -0.0, 0.0, 0.0, 1.0, 0.0, flameout
+
+	sound_vent_medium = engage
+	sound_rocket_hard = running
+	sound_vent_soft = disengage
+	sound_explosion_low = flameout
+
+	TechRequired = aerodynamicSystems
+	entryCost = 4200
+	cost = 450
+	category = Engine
+	subcategory = 0
+
+	title = Dreamer Monoprop OMS //JVS was #DRM-drm-engine-titl. Localize this new monoprop version later.
+	manufacturer = #AAL-Agency-desc
+	description = Prototype monopropellant engine, allowing Dreamer to use a single fuel type for thrust and RCS. //JVS was #DRM-drm-engine-desc. Localize this new monoprop version later.
+	tags = #autoLOC_500468 // maneuver manoeuvre orbital probe propuls (puff thruster
+
+	mass = 0.05 // 0.01
+	heatConductivity = 0.06 // half default
+	skinInternalConductionMult = 4.0
+	emissiveConstant = 0.8 // engine nozzles are good at radiating.
+
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 2
+
+	crashTolerance = 7
+	breakingForce = 150
+	breakingTorque = 150
+
+	maxTemp = 2000
+	PhysicsSignificance = 1
+
+	MODULE
+	{
+		name = ModuleEngines
+		thrustVectorTransformName = thrustTransform
+		exhaustDamage = False
+		ignitionThreshold = 0.1
+		minThrust = 0
+		maxThrust = 10
+		heatProduction = 15
+		fxOffset = 0, 0, 0.4
+		EngineType = MonoProp
+		PROPELLANT
+		{
+			name = MonoPropellant
+			ratio = 0.9
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 310
+			key = 1 290 -21.23404 -21.23404
+			key = 5 230 -10.54119 -10.54119
+			key = 10 170 -13.59091 -13.59091
+			key = 20 0.001
+		}
+		
+	}
+
+	MODULE
+	{
+		name = KM_Gimbal_3
+		gimbalTransformName = thrustTransform
+		trustTransformName = thrustTransform
+		yawGimbalRange = 10.0
+		pitchGimbalRange = 10.0
+		responseSpeed = 50
+ 		useGimbalResponseSpeed = true
+		enableRoll = false
+	}
+
+	MODULE
+	{
+		name = FXModuleAnimateThrottle
+		animationName = PuffNozzleGlow
+		responseSpeed = 0.001
+		dependOnEngineState = True
+		dependOnThrottle = True
+	}	
+
+	// JVS mono engine usually don't produce EC
+	//MODULE
+	//{
+	//	name = ModuleAlternator	
+	//	RESOURCE
+	//	{
+	//		name = ElectricCharge
+	//		rate = 8.0
+	//	}
+	//}
+
+	DRAG_CUBE
+	{
+		cube = Default, 0.09473,0.6127,0.3214, 0.09473,0.6127,0.3214, 0.1485,0.8865,0.41, 0.1485,0.8176,0.27, 0.09473,0.6135,0.3214, 0.09473,0.612,0.3214, 2.496E-09,-0.1651,-0.01653, 0.4453,0.31,0.4453
+	}
+}

--- a/GameData/AxialAerospace/Dreamer/Parts/drm-nose-dock.cfg
+++ b/GameData/AxialAerospace/Dreamer/Parts/drm-nose-dock.cfg
@@ -102,16 +102,17 @@ PART
 		endEventGUIName = #autoLOC_502072 // Close Shield
 		actionGUIName = #autoLOC_502070 // Toggle Shield
 	}
-		
-	MODULE
-	{
-		name = ModuleControlSurface
-		useInternalDragModel = True
-		dragCoeff = 0.10
-		deflectionLiftCoeff = 1.1	 //1.3
-		ctrlSurfaceRange = 45	 
-		ctrlSurfaceArea = 3.5		
-	}
+
+// JVS stop lift and control surface from nose
+//	MODULE
+//	{
+//		name = ModuleControlSurface
+//		useInternalDragModel = True
+//		dragCoeff = 0.10
+//		deflectionLiftCoeff = 1.1	 //1.3
+//		ctrlSurfaceRange = 45	 
+//		ctrlSurfaceArea = 3.5		
+//	}
 
 	MODULE
 	{
@@ -224,8 +225,8 @@ PART
 	RESOURCE
 	{
 		name = MonoPropellant
-		amount = 10
-		maxAmount = 20
+		amount = 30 //10  // JVS increased to match nondocking nose
+		maxAmount = 30 //20  // JVS increased to match nondocking nose
 	}
 
 	RESOURCE

--- a/GameData/AxialAerospace/Dreamer/Parts/drm-nose-nodock.cfg
+++ b/GameData/AxialAerospace/Dreamer/Parts/drm-nose-nodock.cfg
@@ -63,15 +63,16 @@ PART
 		actionGUIName = #autoLOC_502070 // Toggle Shield
 	}
 
-	MODULE
-	{
-		name = ModuleControlSurface
-		useInternalDragModel = True
-		dragCoeff = 0.10
-		deflectionLiftCoeff = 1.1	//1.3
-		ctrlSurfaceRange = 45	
-		ctrlSurfaceArea = 3.5		
-	}
+// JVS stop lift and control surface from nose
+//	MODULE
+//	{
+//		name = ModuleControlSurface
+//		useInternalDragModel = True
+//		dragCoeff = 0.10
+//		deflectionLiftCoeff = 1.1	//1.3
+//		ctrlSurfaceRange = 45	
+//		ctrlSurfaceArea = 3.5		
+//	}
 
 	MODULE
 	{
@@ -186,7 +187,7 @@ PART
 	RESOURCE
 	{
 		name = MonoPropellant
-		amount = 15
+		amount = 30  //15 //JVS increased to max. If someone needs tint mass saving they can reduce it later in VAB
 		maxAmount = 30
 	}
 

--- a/GameData/AxialAerospace/Dreamer/Parts/drm-tail.cfg
+++ b/GameData/AxialAerospace/Dreamer/Parts/drm-tail.cfg
@@ -66,35 +66,38 @@ PART
 		name = ModuleControlSurface
 		useInternalDragModel = True
 		dragCoeff = 0.40
-		deflectionLiftCoeff = 3.5	//3.8
+		deflectionLiftCoeff = 0.5  //3.5	//3.8  // JVS
 		ctrlSurfaceRange = 35	//20 
-		ctrlSurfaceArea = 5.4	//1.5
+		ctrlSurfaceArea = 0.54 //5.4	//1.5  //JVS the "5.4" was giving 540%, a ridiculously overpowered rudder causing crazy turns
 		transformName = nodeTail
 	}
 	
-	MODULE
-	{
-		name = ModuleAeroSurface
-		useInternalDragModel = True
-		dragCoeff = 0.6
-		deflectionLiftCoeff = 0.38
-		ctrlSurfaceRange = 70
-		ctrlRangeFactor = 0.2
-		ctrlSurfaceArea = 1
-		actuatorSpeed = 20
-		transformName = airbrakes // Flap
-		defaultActionGroup = Brakes
-		liftingSurfaceCurve = SpeedBrake
-		ignorePitch = true
-		ignoreYaw = true
-		uncasedTemp = 1200
-		casedTemp = 2400
-	}
+	// JVS airbrakes not needed at all. Body and wings already give good blend of lift, drag, control to slow down.
+	//MODULE
+	//{
+	//	name = ModuleAeroSurface
+	//	useInternalDragModel = True
+	//	dragCoeff = 0.6
+	//	deflectionLiftCoeff = 0.38
+	//	ctrlSurfaceRange = 70
+	//	ctrlRangeFactor = 0.2
+	//	ctrlSurfaceArea = 1
+	//	actuatorSpeed = 20
+	//	transformName = airbrakes // Flap
+	//	defaultActionGroup = Brakes
+	//	liftingSurfaceCurve = SpeedBrake
+	//	ignorePitch = true
+	//	ignoreYaw = true
+	//	uncasedTemp = 1200
+	//	casedTemp = 2400
+	//}
 
-	DRAG_CUBE
-	{
-		cube = neutral, 0.8316,0.9898,1.019, 0.8316,0.75,1.657, 0.7977,0.8997,1.517, 0.7977,0.8996,1.517, 0.1674,0.2476,2.118, 0.1674,0.5294,1.751, -0.5688,-0.04602,0.3239, 1.568,2.847,2.032
-		cube = fullDeflectionPos, 0.8316,0.9898,1.019, 0.8316,0.75,1.657, 0.7977,0.8997,1.517, 0.7977,0.8996,1.517, 0.1674,0.2476,2.118, 0.1674,0.5294,1.751, -0.5688,-0.04602,0.3239, 1.568,2.847,2.032
-		cube = fullDeflectionNeg, 0.8316,0.9898,1.019, 0.8316,0.75,1.657, 0.7977,0.8997,1.517, 0.7977,0.8996,1.517, 0.1674,0.2476,2.118, 0.1674,0.5294,1.751, -0.5688,-0.04602,0.3239, 1.568,2.847,2.032
-	}
+	// JVS Without the airbrake function these cubes need revision. Prior testing suggest teh neutral position drag was far too high. Tail is small so just let default cubes get
+	// generated to see what happens.
+	//DRAG_CUBE
+	//{
+	//	cube = neutral, 0.8316,0.9898,1.019, 0.8316,0.75,1.657, 0.7977,0.8997,1.517, 0.7977,0.8996,1.517, 0.1674,0.2476,2.118, 0.1674,0.5294,1.751, -0.5688,-0.04602,0.3239, 1.568,2.847,2.032
+	//	cube = fullDeflectionPos, 0.8316,0.9898,1.019, 0.8316,0.75,1.657, 0.7977,0.8997,1.517, 0.7977,0.8996,1.517, 0.1674,0.2476,2.118, 0.1674,0.5294,1.751, -0.5688,-0.04602,0.3239, 1.568,2.847,2.032
+	//	cube = fullDeflectionNeg, 0.8316,0.9898,1.019, 0.8316,0.75,1.657, 0.7977,0.8997,1.517, 0.7977,0.8996,1.517, 0.1674,0.2476,2.118, 0.1674,0.5294,1.751, -0.5688,-0.04602,0.3239, 1.568,2.847,2.032
+	//}
 }


### PR DESCRIPTION
Change summary. All cfg changes commented with "JVS". 1) Fixed several aero parts. Problem originally looked like simple drag, later traced to too much lift and ridiculously large control surfaces out of scale to the models. Modest control inputs could generate 60G lateral forces causing aero instability and part explosions. Changes improved ascent, reentry, and landing behavior. 2) Increased heat resistance of both cabins for 2.5x scale. Steep reentry can still cause burnup so there's still some risk for cowboy pilots. 3) OMS Engine seemed overpowered. Left as-is and added weaker monoprop engine. Allows Dreamer vehicle to use single fuel for orbital engines and RCS. 4) Removed airbrake module from tail. It wasn't needed to slow down, and was easier to remove than to fix.

Remaining Work
1) Skyhawk strongly nerfs reaction wheels. Temporarily upped wheels by x100 to compensate. After aero settings are tested more will bring wheels back to reasonable values, and maybe create a patch for Skyhawk because, while aero is much better than before, strong reaction wheels help Dreamer (other aero tricks such as offsetting wings or adding canards aren't viable with these models). 2) The non-cargo cabin's front node is too far forwards. Nose Cone and Docking NoseCone have to be offset when attached. First attempt to move node copying same settings as cargo cabin did not yield correct placement; the 2 cabins might have different origin points or slightly different sizes. 3) Most testing was at 2.5x KSRSS scale. Some chnages have not been tested with stock 1x Kerbin. 4) I've done zero testing of the included lifter parts. 5) The new engine hasn't been localized, hardcoded English text. 6) Check player.log for errors.

Signed-off-by: jvsperoni <125160931+jvsperoni@users.noreply.github.com>